### PR TITLE
fixed type of input rendered in create-recipe.js

### DIFF
--- a/create-recipe/create-recipe.js
+++ b/create-recipe/create-recipe.js
@@ -67,7 +67,7 @@ newIngredientRowButton.addEventListener('click', () => {
         itemNameInput.setAttribute('placeholder', 'name');
 
         const quanInput = document.createElement('input');
-        quanInput.setAttribute('type', 'number');
+        quanInput.setAttribute('type', 'text');
         quanInput.setAttribute('value', '1');
         quanInput.setAttribute('name', `quantity-${i + 1}`);
         quanInput.setAttribute('placeholder', 'quantity');


### PR DESCRIPTION
after adding an ingredient row on create recipe page, quantity input type was set to "number" instead of "text"